### PR TITLE
refactor: use setinterval instead of while loop in tx broadcaster

### DIFF
--- a/stacking/package.json
+++ b/stacking/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "format": "prettier --write *.ts",
-    "flood": "dotenvx run -f ./tx-broadcaster.env -- npx tsx flood.ts"
+    "flood": "dotenvx run -f ./tx-broadcaster.env -- npx tsx flood.ts",
+    "tx-broadcaster": "dotenvx run -f ./tx-broadcaster.env -- npx tsx tx-broadcaster.ts"
   },
   "keywords": [],
   "author": "",
@@ -13,12 +14,12 @@
   "dependencies": {
     "@stacks/api": "6.11.4-pr.472091f.0",
     "@stacks/blockchain-api-client": "7.8.2",
-    "@stacks/common": "6.11.4-pr.36558cf.0",
-    "@stacks/encryption": "6.11.4-pr.36558cf.0",
-    "@stacks/network": "6.11.4-pr.36558cf.0",
-    "@stacks/stacking": "6.11.4-pr.36558cf.0",
-    "@stacks/stacks-blockchain-api-types": "7.8.2",
-    "@stacks/transactions": "6.11.4-pr.36558cf.0",
+    "@stacks/common": "6.16.0",
+    "@stacks/encryption": "6.16.1",
+    "@stacks/network": "6.16.0",
+    "@stacks/stacking": "6.16.1",
+    "@stacks/stacks-blockchain-api-types": "7.13.2",
+    "@stacks/transactions": "6.16.1",
     "dotenv": "^16.4.5",
     "pino": "^8.19.0",
     "pino-pretty": "^10.3.1"

--- a/stacking/tx-broadcaster.ts
+++ b/stacking/tx-broadcaster.ts
@@ -60,7 +60,7 @@ async function broadcast(tx: StacksTransaction, sender?: string) {
     return false;
   } else {
     if (label.includes('Flooder')) return true;
-    logger.debug(`Broadcast ${txType} from ${label} tx=${broadcastResult.txid}`);
+    logger.debug(`Broadcast ${txType} from ${label} tx=${broadcastResult.txid} at ${new Date()}`);
     return true;
   }
 }
@@ -98,15 +98,15 @@ function accountLabel(address: string) {
   return `Unknown (${address})`;
 }
 
-async function loop() {
+async function main() {
   await waitForNakamoto();
-  while (true) {
+  setInterval(async () => {
     try {
       await run();
     } catch (e) {
       logger.error('Error submitting stx-transfer tx:', e);
     }
-    await new Promise(resolve => setTimeout(resolve, broadcastInterval * 1000));
-  }
+  }, broadcastInterval * 1000);
 }
-loop();
+
+main();


### PR DESCRIPTION
## Context

It was discovered that the tx pace slows down in time.
This PR attempts to make sure that the timing is more linear and closer to the desired interval.
With this `setInterval`, we boradcast tx every N seconds, and it's not impacted by networks.

With the `while (true)`, we would wait for the previous tx to be broadcasted + N seconds to broadcast the next tx.

We'll have to keep an eye on the logs, but this could ensure stable tx pace