### PR TITLE
feat: add env variable STACK_AMOUNT_STX to override stacking amount

### DIFF
--- a/stacking/stacking.ts
+++ b/stacking/stacking.ts
@@ -14,6 +14,7 @@ const randInt = () => crypto.randomInt(0, 0xffffffffffff);
 const stackingInterval = parseEnvInt('STACKING_INTERVAL', true);
 const postTxWait = parseEnvInt('POST_TX_WAIT', true);
 const stackingCycles = parseEnvInt('STACKING_CYCLES', true);
+const stackAmount = parseEnvInt('STACK_AMOUNT_STX', false);
 
 let startTxFee = 1000;
 const getNextTxFee = () => startTxFee++;
@@ -107,7 +108,11 @@ async function run() {
 async function stackStx(poxInfo: PoxInfo, account: Account, balance: bigint) {
   // Bump min threshold by 50% to avoid getting stuck if threshold increases
   const minStx = Math.floor(poxInfo.next_cycle.min_threshold_ustx * 1.5);
-  const amountToStx = BigInt(minStx) * BigInt(account.targetSlots);
+  let amountToStx = BigInt(minStx) * BigInt(account.targetSlots);
+  if (typeof stackAmount === 'number') {
+    amountToStx = BigInt(stackAmount) * 1_000_000n;
+  }
+  
   if (amountToStx > balance) {
     throw new Error(
       `Insufficient balance to stack-stx (amount=${amountToStx}, balance=${balance})`

--- a/stacking/tx-broadcaster.ts
+++ b/stacking/tx-broadcaster.ts
@@ -104,7 +104,7 @@ async function loop() {
     try {
       await run();
     } catch (e) {
-      logger.error('Error submitting stx-transfer tx:', e);
+      logger.error(e, 'Error in tx-broadcaster loop');
     }
     await new Promise(resolve => setTimeout(resolve, broadcastInterval * 1000));
   }

--- a/stacks-krypton-follower.toml
+++ b/stacks-krypton-follower.toml
@@ -137,3 +137,9 @@ amount = 10000000000000000
 address = "STEH2J3C05BAHYS0RBAQBANJ1AXR6SR43VMZ0D49"
 amount = 10000000000000000
 # secretKey = 5b8303150239eceaba43892af7cdd1fa7fc26eda5182ebaaa568e3341d54a4d001
+
+[[ustx_balance]]
+address = "STT8DSJTWAW9TVJ1B17SD3S6F7SYH4TXG7TWS7Q9"
+amount = 10000000000000000
+# privateKey = 16226f674796712dfbd53bf402304579b8b6d04d4bed4d466bf84ce6db973d4401
+# mnemonic = "essay grief twin tube concert idea prosper good alarm goddess shell glare hurt belt endless patch lumber wrap labor body erupt brown style test"

--- a/stacks-krypton-miner.toml
+++ b/stacks-krypton-miner.toml
@@ -186,3 +186,9 @@ amount = 10000000000000000
 address = "STEH2J3C05BAHYS0RBAQBANJ1AXR6SR43VMZ0D49"
 amount = 10000000000000000
 # secretKey = 5b8303150239eceaba43892af7cdd1fa7fc26eda5182ebaaa568e3341d54a4d001
+
+[[ustx_balance]]
+address = "STT8DSJTWAW9TVJ1B17SD3S6F7SYH4TXG7TWS7Q9"
+amount = 10000000000000000
+# privateKey = 16226f674796712dfbd53bf402304579b8b6d04d4bed4d466bf84ce6db973d4401
+# mnemonic = "essay grief twin tube concert idea prosper good alarm goddess shell glare hurt belt endless patch lumber wrap labor body erupt brown style test"


### PR DESCRIPTION
Adds an ENV variable `STACK_AMOUNT_STX`. If provided, the stacking script will stack this amount (in STX, not uSTX). This is helpful for scenarios where we want to stack more than just a few slots per account.