### PR TITLE
fix: allow custom chain ID in JS scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  STACKS_BLOCKCHAIN_COMMIT: d0f5712332619b3140badc2d25856975d2747004
+  STACKS_BLOCKCHAIN_COMMIT: e2bd98230483a3ee18d03cbfccfc795dbdcb2004
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 x-common-vars:
-  - &STACKS_BLOCKCHAIN_COMMIT a4597f5626217a6198dd9925bb1296f3bb576eeb # develop, Oct 2, 22:30
+  - &STACKS_BLOCKCHAIN_COMMIT 21a196ac7ddba19cda646623f55be55826eb163d # develop, Oct 14, 12:20 PST
   - &STACKS_API_COMMIT f6e50f6d28f292d79dbebd70b2b00831c95997f6 # 7.13.2
   - &BITCOIN_ADDRESSES miEJtNKa3ASpA19v5ZhvbKTEieYjLpzCYT
   - &MINER_SEED 9e446f6b0c6a96cf2190e54bcd5a8569c3e386f091605499464389b8d4e0bfc201 # stx: STEW4ZNT093ZHK4NEQKX8QJGM2Y7WWJ2FQQS5C19, btc: miEJtNKa3ASpA19v5ZhvbKTEieYjLpzCYT, pub_key: 035379aa40c02890d253cfa577964116eb5295570ae9f7287cbae5f2585f5b2c7c, wif: cStMQXkK5yTFGP3KbNXYQ3sJf2qwQiKrZwR9QJnksp32eKzef1za
@@ -27,6 +27,10 @@ x-common-vars:
   - &POX_REWARD_LENGTH ${POX_REWARD_LENGTH:-20}
   - &REWARD_RECIPIENT ${REWARD_RECIPIENT:-STQM73RQC4EX0A07KWG1J5ECZJYBZS4SJ4ERC6WN} # priv: 6ad9cadb42d4edbfbe0c5bfb3b8a4125ddced021c4174f829b714ccbf527f02001
   - &EXIT_FROM_MONITOR 1 # set to "1" to automatically shut down via monitor.ts
+  # Choose one to override the default
+  # - &STACKS_CHAIN_ID ${STACKS_CHAIN_ID:-0x80000000}
+  - &STACKS_CHAIN_ID ${STACKS_CHAIN_ID:-0x80000100}
+  - &CUSTOM_CHAIN_IDS ${CUSTOM_CHAIN_IDS:-testnet=0x55005500,mainnet=12345678,mainnet=0xdeadbeaf,testnet=0x80000100}
 
 services:
   bitcoind:
@@ -249,6 +253,7 @@ services:
       POX_PREPARE_LENGTH: *POX_PREPARE_LENGTH
       POX_REWARD_LENGTH: *POX_REWARD_LENGTH
       REWARD_RECIPIENT: *REWARD_RECIPIENT
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
     entrypoint:
       - /bin/bash
       - -c
@@ -260,6 +265,7 @@ services:
         mkdir -p $${DATA_DIR}
         rm -rf $${DATA_DIR}/*
         envsubst < config.toml.in > config.toml
+        echo "Starting Stacks with config: $(cat config.toml)"
         bitcoin-cli -rpcwait -rpcconnect=bitcoind getmininginfo
         exec stacks-node start --config config.toml
 
@@ -278,6 +284,7 @@ services:
       STACKS_30_HEIGHT: *STACKS_30_HEIGHT
       POX_PREPARE_LENGTH: *POX_PREPARE_LENGTH
       POX_REWARD_LENGTH: *POX_REWARD_LENGTH
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
       STACKING_INTERVAL: 2 # interval (seconds) for checking if stacking transactions are needed
       POST_TX_WAIT: 10 # seconds to wait after a stacking transaction broadcast before continuing the loop
       SERVICE_NAME: stacker
@@ -300,6 +307,7 @@ services:
       POX_PREPARE_LENGTH: *POX_PREPARE_LENGTH
       POX_REWARD_LENGTH: *POX_REWARD_LENGTH
       EXIT_FROM_MONITOR: *EXIT_FROM_MONITOR
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
       SERVICE_NAME: monitor
     depends_on:
       - stacks-node
@@ -325,6 +333,7 @@ services:
       STACKS_25_HEIGHT: *STACKS_25_HEIGHT
       POX_PREPARE_LENGTH: *POX_PREPARE_LENGTH
       POX_REWARD_LENGTH: *POX_REWARD_LENGTH
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
       STACKING_KEYS: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01,b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401,7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
     depends_on:
       - stacks-node
@@ -367,7 +376,7 @@ services:
     environment:
       NODE_ENVIRONMENT: production
       STACKS_API_LOG_LEVEL: debug
-      STACKS_CHAIN_ID: "0x80000000"
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
       STACKS_BLOCKCHAIN_API_HOST: "0.0.0.0"
       STACKS_BLOCKCHAIN_API_PORT: 3999
       STACKS_CORE_EVENT_HOST: "0.0.0.0"
@@ -385,6 +394,7 @@ services:
       BTC_RPC_USER: btc
       BTC_RPC_PW: btc
       BTC_FAUCET_PK: *MINER_SEED
+      CUSTOM_CHAIN_IDS: *CUSTOM_CHAIN_IDS
 
   stacks-signer-1:
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ x-common-vars:
   - &BITCOIN_RPC_USER btc
   - &BITCOIN_RPC_PASS btc
   - &MINE_INTERVAL ${MINE_INTERVAL:-1s}
-  - &MINE_INTERVAL_EPOCH25 ${MINE_INTERVAL_EPOCH25:-5s} # 10 second bitcoin block times in epoch 2.5
-  - &MINE_INTERVAL_EPOCH3 ${MINE_INTERVAL_EPOCH3:-30s} # 10 minute bitcoin block times in epoch 3
+  - &MINE_INTERVAL_EPOCH25 ${MINE_INTERVAL_EPOCH25:-5s} # 5 second bitcoin block times in epoch 2.5
+  - &MINE_INTERVAL_EPOCH3 ${MINE_INTERVAL_EPOCH3:-30s} # 30 second bitcoin block times in epoch 3
   - &NAKAMOTO_BLOCK_INTERVAL 2 # seconds to wait between issuing stx-transfer transactions (which triggers Nakamoto block production)
   - &STACKS_20_HEIGHT ${STACKS_20_HEIGHT:-0}
   - &STACKS_2_05_HEIGHT ${STACKS_2_05_HEIGHT:-102}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 x-common-vars:
-  - &STACKS_BLOCKCHAIN_COMMIT 21a196ac7ddba19cda646623f55be55826eb163d # develop, Oct 14, 12:20 PST
+  - &STACKS_BLOCKCHAIN_COMMIT e2bd98230483a3ee18d03cbfccfc795dbdcb2004 # develop, Oct 14, 12:20 PST
   - &STACKS_API_COMMIT f6e50f6d28f292d79dbebd70b2b00831c95997f6 # 7.13.2
   - &BITCOIN_ADDRESSES miEJtNKa3ASpA19v5ZhvbKTEieYjLpzCYT
   - &MINER_SEED 9e446f6b0c6a96cf2190e54bcd5a8569c3e386f091605499464389b8d4e0bfc201 # stx: STEW4ZNT093ZHK4NEQKX8QJGM2Y7WWJ2FQQS5C19, btc: miEJtNKa3ASpA19v5ZhvbKTEieYjLpzCYT, pub_key: 035379aa40c02890d253cfa577964116eb5295570ae9f7287cbae5f2585f5b2c7c, wif: cStMQXkK5yTFGP3KbNXYQ3sJf2qwQiKrZwR9QJnksp32eKzef1za
@@ -10,7 +10,7 @@ x-common-vars:
   - &BITCOIN_RPC_USER btc
   - &BITCOIN_RPC_PASS btc
   - &MINE_INTERVAL ${MINE_INTERVAL:-1s}
-  - &MINE_INTERVAL_EPOCH25 ${MINE_INTERVAL_EPOCH25:-10s} # 10 second bitcoin block times in epoch 2.5
+  - &MINE_INTERVAL_EPOCH25 ${MINE_INTERVAL_EPOCH25:-5s} # 10 second bitcoin block times in epoch 2.5
   - &MINE_INTERVAL_EPOCH3 ${MINE_INTERVAL_EPOCH3:-30s} # 10 minute bitcoin block times in epoch 3
   - &NAKAMOTO_BLOCK_INTERVAL 2 # seconds to wait between issuing stx-transfer transactions (which triggers Nakamoto block production)
   - &STACKS_20_HEIGHT ${STACKS_20_HEIGHT:-0}
@@ -414,6 +414,7 @@ services:
       STACKS_NODE_HOST: stacks-node:20443
       STACKS_SIGNER_ENDPOINT: 0.0.0.0:30001
       SIGNER_PRIVATE_KEY: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
     entrypoint:
       - /bin/bash
       - -c
@@ -440,6 +441,7 @@ services:
       STACKS_NODE_HOST: stacks-node:20443
       STACKS_SIGNER_ENDPOINT: 0.0.0.0:30002
       SIGNER_PRIVATE_KEY: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
     entrypoint:
       - /bin/bash
       - -c
@@ -466,6 +468,7 @@ services:
       STACKS_NODE_HOST: stacks-node:20443
       STACKS_SIGNER_ENDPOINT: 0.0.0.0:30003
       SIGNER_PRIVATE_KEY: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+      STACKS_CHAIN_ID: *STACKS_CHAIN_ID
     entrypoint:
       - /bin/bash
       - -c

--- a/signer-0.toml
+++ b/signer-0.toml
@@ -5,3 +5,4 @@ endpoint = "$STACKS_SIGNER_ENDPOINT" # e.g 127.0.0.1:30000
 network = "testnet"
 auth_password = "12345"
 db_path = "$SIGNER_DB_PATH"
+chain_id = $STACKS_CHAIN_ID

--- a/stacking/common.ts
+++ b/stacking/common.ts
@@ -38,7 +38,7 @@ if (process.env.STACKS_LOG_JSON === '1') {
   });
 }
 
-export const CHAIN_ID = parseEnvInt('CHAIN_ID', false) ?? ChainID.Testnet;
+export const CHAIN_ID = parseEnvInt('STACKS_CHAIN_ID', false) ?? ChainID.Testnet;
 
 export const nodeUrl = `http://${process.env.STACKS_CORE_RPC_HOST}:${process.env.STACKS_CORE_RPC_PORT}`;
 export const network = new StacksTestnet({ url: nodeUrl });
@@ -106,6 +106,9 @@ export function parseEnvInt<T extends boolean = false>(
       throw new Error(`Missing required env var: ${envKey}`);
     }
     return undefined as T extends true ? number : number | undefined;
+  }
+  if (value.startsWith('0x')) {
+    return parseInt(value, 16);
   }
   return parseInt(value, 10);
 }

--- a/stacking/common.ts
+++ b/stacking/common.ts
@@ -15,6 +15,7 @@ import {
   AccountsApi,
 } from '@stacks/blockchain-api-client';
 import pino, { Logger } from 'pino';
+import { ChainID } from '@stacks/common';
 
 const serviceName = process.env.SERVICE_NAME || 'JS';
 export let logger: Logger;
@@ -37,8 +38,11 @@ if (process.env.STACKS_LOG_JSON === '1') {
   });
 }
 
+export const CHAIN_ID = parseEnvInt('CHAIN_ID', false) ?? ChainID.Testnet;
+
 export const nodeUrl = `http://${process.env.STACKS_CORE_RPC_HOST}:${process.env.STACKS_CORE_RPC_PORT}`;
 export const network = new StacksTestnet({ url: nodeUrl });
+network.chainId = CHAIN_ID;
 const apiConfig = new Configuration({
   basePath: nodeUrl,
 });

--- a/stacking/stacking.ts
+++ b/stacking/stacking.ts
@@ -141,10 +141,11 @@ async function stackStx(poxInfo: PoxInfo, account: Account, balance: bigint) {
     authId,
     maxAmount,
   };
+  const { signerPrivateKey, ...restSigArgs } = sigArgs;
   account.logger.debug(
     {
       ...stackingArgs,
-      ...sigArgs,
+      ...restSigArgs,
     },
     `Stack-stx with args:`
   );
@@ -179,12 +180,13 @@ async function stackExtend(poxInfo: PoxInfo, account: Account) {
     authId,
     maxAmount,
   };
+  const { signerPrivateKey, ...restSigArgs } = sigArgs;
   account.logger.debug(
     {
       stxAddress: account.stxAddress,
       account: account.index,
       ...stackingArgs,
-      ...sigArgs,
+      ...restSigArgs,
     },
     `Stack-extend with args:`
   );

--- a/stacking/stacking.ts
+++ b/stacking/stacking.ts
@@ -112,7 +112,7 @@ async function stackStx(poxInfo: PoxInfo, account: Account, balance: bigint) {
   if (typeof stackAmount === 'number') {
     amountToStx = BigInt(stackAmount) * 1_000_000n;
   }
-  
+
   if (amountToStx > balance) {
     throw new Error(
       `Insufficient balance to stack-stx (amount=${amountToStx}, balance=${balance})`

--- a/stacking/tx-broadcaster.ts
+++ b/stacking/tx-broadcaster.ts
@@ -8,11 +8,12 @@ import {
   broadcastTransaction,
   StacksTransaction,
 } from '@stacks/transactions';
-import { logger } from './common';
+import { logger, CHAIN_ID } from './common';
 
 const broadcastInterval = parseInt(process.env.NAKAMOTO_BLOCK_INTERVAL ?? '2');
 const url = `http://${process.env.STACKS_CORE_RPC_HOST}:${process.env.STACKS_CORE_RPC_PORT}`;
 const network = new StacksTestnet({ url });
+network.chainId = CHAIN_ID;
 const EPOCH_30_START = parseInt(process.env.STACKS_30_HEIGHT ?? '0');
 
 const accounts = process.env.ACCOUNT_KEYS!.split(',').map(privKey => ({

--- a/stacks-krypton-follower.toml
+++ b/stacks-krypton-follower.toml
@@ -34,6 +34,7 @@ chain = "bitcoin"
 mode = "krypton"
 poll_time_secs = 1
 pox_2_activation = $STACKS_POX2_HEIGHT
+chain_id = $STACKS_CHAIN_ID
 
 ### bitcoind-regtest connection info
 peer_host = "$BITCOIN_PEER_HOST"

--- a/stacks-krypton-miner.toml
+++ b/stacks-krypton-miner.toml
@@ -20,10 +20,8 @@ microblock_frequency = 1000
 # max_microblocks = 10
 
 [miner]
-min_tx_fee = 1
 first_attempt_time_ms = 180_000
 subsequent_attempt_time_ms = 360_000
-wait_for_block_download = false
 microblock_attempt_time_ms = 10
 #self_signing_seed = 1
 mining_key = "19ec1c3e31d139c989a23a27eac60d1abfad5277d3ae9604242514c738258efa01"
@@ -42,27 +40,19 @@ auth_token = "12345"
 # Add stacks-api as an event observer
 [[events_observer]]
 endpoint = "stacks-api:3700"
-retry_count = 255
-include_data_events = false
 events_keys = ["*"]
 
 # Add stacks-signer as an event observer
 [[events_observer]]
 endpoint = "stacks-signer-1:30001"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [[events_observer]]
 endpoint = "stacks-signer-2:30002"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [[events_observer]]
 endpoint = "stacks-signer-3:30003"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [burnchain]
@@ -73,7 +63,7 @@ magic_bytes = "T3"
 pox_prepare_length = $POX_PREPARE_LENGTH
 pox_reward_length = $POX_REWARD_LENGTH
 burn_fee_cap = 20_000
-
+chain_id = $STACKS_CHAIN_ID
 ### bitcoind-regtest connection info
 peer_host = "$BITCOIN_PEER_HOST"
 peer_port = $BITCOIN_PEER_PORT


### PR DESCRIPTION
Set `STACKS_CHAIN_ID` to override JS-driven transaction's chain ID, which is required when using a custom network. Defaults to the testnet chain ID otherwise.

Also updated the docker compose file for the latest develop, which required removing some (invalid) config fields from the Stacks config file.